### PR TITLE
Set exact `androidx.browser:browser` version to enable CI to build Android apk's

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     def androidXAnnotation = safeExtGet('androidXAnnotation', androidXVersion)
     def androidXBrowser = safeExtGet('androidXBrowser', androidXVersion)
     implementation "androidx.annotation:annotation:$androidXAnnotation"
-    implementation "androidx.browser:browser:$androidXBrowser"
+    implementation "androidx.browser:browser:1.5.0"
   }
 }
   


### PR DESCRIPTION
This PR contains only one change, it sets direct version of `androidx.browser:browser` to 1.6.0 instead of using the newest available. Because of recently released `androidx.browser:browser:1.6.0-beta01` we cannot build new Android apps, as the problem is as follows:

```
Dependency 'androidx.browser:browser:1.6.0-beta01' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.
     
           :app is currently compiled against android-33.
     
           Also, the maximum recommended compile SDK version for Android Gradle
           plugin 7.3.0 is 33.
```

And we are not planning to bump Android SDK to the newest one now, as it will demand lot of work (as usually) and we already have lot of tasks to be done.

Link to broken job example: https://github.com/TeamAround/Around/actions/runs/5343837271/jobs/9687452765